### PR TITLE
potential code refactor

### DIFF
--- a/scrapera/audio/youtube_playlist_scraper.py
+++ b/scrapera/audio/youtube_playlist_scraper.py
@@ -19,7 +19,7 @@ class PlaylistScraper:
         out_path: [Optional] Path to the output directory. If unspecified, current directory is used
     '''
     def __init__(self, url, bitrate, out_path):
-        assert type(bitrate) == int and bitrate in [16, 24, 32, 48, 56, 64, 96, 128, 160, 192, 256, 320],\
+        assert type(bitrate) is int and bitrate in [16, 24, 32, 48, 56, 64, 96, 128, 160, 192, 256, 320],\
             "Bitrate must be one of [16,24,32,48,56,64,96,128,160,192,256,320]"
 
         self.url = url

--- a/scrapera/image/instagram.py
+++ b/scrapera/image/instagram.py
@@ -8,7 +8,8 @@ from PIL import Image
 
 
 class InstagramImageScraper:
-    def _extract_image(self, json_response, out_path=None, resize=None):
+    @staticmethod
+    def _extract_image(json_response, out_path=None, resize=None):
         name_of_file = str(json_response['graphql']['shortcode_media']['owner']['username']) + '_' + str(
             json_response['graphql']['shortcode_media']['id'])
         img_link = json_response['graphql']['shortcode_media']['display_resources'][-1]['src']

--- a/scrapera/image/instagram.py
+++ b/scrapera/image/instagram.py
@@ -43,7 +43,7 @@ class InstagramImageScraper:
         urllib_proxies:  [Optional] dict, Proxy information for urllib requests
         '''
         if urllib_proxies:
-            assert type(urllib_proxies) == dict, "Input to 'urllib_proxies' should be a dictionary"
+            assert type(urllib_proxies) is dict, "Input to 'urllib_proxies' should be a dictionary"
         if out_path:
             assert os.path.isdir(out_path), "Invalid output directory"
         assert type(resize) in [list, tuple, set] and len(

--- a/scrapera/text/amazon.py
+++ b/scrapera/text/amazon.py
@@ -44,7 +44,7 @@ class AmazonReviewScraper:
             a_tags = self.driver.find_elements_by_class_name('a-link-normal')
             for a_tag in a_tags:
                 href = a_tag.get_attribute('href')
-                flag = True if re.findall(r's[/]?\?k=', href) != [] else False
+                flag = re.findall(r's[/]?\?k=', href) != []
                 if 'customerReviews' not in href and not flag \
                         and 'help' not in href and 'amazon-adsystem' not in href:
                     all_links.add(href)

--- a/scrapera/text/instagram.py
+++ b/scrapera/text/instagram.py
@@ -7,7 +7,8 @@ import urllib
 
 
 class InstagramCommentsScraper:
-    def _extract_get_comments_data(self, json_response):
+    @staticmethod
+    def _extract_get_comments_data(json_response):
         comments_list, usernames_list, timestamps_list = [], [], []
         for node in json_response['graphql']['shortcode_media']['edge_media_to_parent_comment']['edges']:
             comments_list.append(node['node']['text'].encode('utf-8', 'replace').decode())

--- a/scrapera/text/voice_of_america.py
+++ b/scrapera/text/voice_of_america.py
@@ -86,7 +86,7 @@ class VOAScraper:
         Scraper function for Voice of America News articles
         num_scrolls: int, Number of times to fetch more entries. Default is 1
         '''
-        assert (type(num_scrolls) == int and num_scrolls >= 0), "Number of scrolls cannot be negative"
+        assert (type(num_scrolls) is int and num_scrolls >= 0), "Number of scrolls cannot be negative"
         all_links = self._get_links(num_scrolls)
         self._get_article_content(all_links)
         self.conn.close()


### PR DESCRIPTION
This PR includes:
- Use `is` instead of `==`
  - It is recommended to use identity test ( is ) instead of equality test ( == ) when you need to compare types of two objects.
- Simplify boolean expression
- Remove `self`
  - The method doesn't use its bound instance. Decorate this method with `@staticmethod` decorator, so that Python does not have to instantiate a bound method for every instance of this class thereby saving memory and computation.